### PR TITLE
Tokens enum

### DIFF
--- a/tokens_enum.hpp
+++ b/tokens_enum.hpp
@@ -17,10 +17,9 @@ enum class TOK {
   UNDEFINED,   // token of undefined kind (i.e. error)
   EOI,         // end of input
   INT_LIT,     // integer literal
-  MAIN,        // main keyword
   INT,         // int keyword
   BOOL,        // bool keyword
-  FUNCTION,    // func keyword
+  FUNC,        // func keyword
   RETURN,      // return keyword
   IF,          // if keyword
   WHILE,       // while keyword
@@ -29,25 +28,25 @@ enum class TOK {
   NEW,         // new keyword
   PLUS,        // + operator
   MINUS,       // - operator
-  MULT,        // * operator
+  MUL,         // * operator
   DIV,         // / operator
   MOD,         // % operator
   ASSIGN,      // = operator
-  EQUAL,       // == operator
-  UNEQUAL,     // != operator
-  GREATER,     // > operator
-  GREQ,        // >= operator
-  LESS,        // < operator
+  EQ,          // == operator
+  NEQ,         // != operator
+  GT,          // > operator
+  GEQ,         // >= operator
+  LT,          // < operator
   LEQ,         // <= operator
   COLON,       // : token
   COMMA,       // , token
   ID,          // function (e.g. quicksort) or variable (e.g. len) identifiers
-  START_ARRAY, // [ token
-  END_ARRAY,   // ] token
-  START_PAREN, // ( token
-  END_PAREN,   // ) token
-  START_SCOPE, // { token
-  END_SCOPE,   // } token
+  LBRACKET,    // [ token
+  RBRACKET,    // ] token
+  LPAR,        // ( token
+  RPAR,        // ) token
+  LBRACE,      // { token
+  RBRACE,      // } token
   SEMICOLON    // ; token
 };
 

--- a/tokens_enum.hpp
+++ b/tokens_enum.hpp
@@ -14,40 +14,40 @@ Therefore to use an enumerator name we have to use the scope resolution
 operator. e.g. TOK::UNDEFINED
 */
 enum class TOK {
-  UNDEFINED,   // token of undefined kind (i.e. error)
-  EOI,         // end of input
-  INT_LIT,     // integer literal
-  INT,         // int keyword
-  BOOL,        // bool keyword
-  FUNC,        // func keyword
-  RETURN,      // return keyword
-  IF,          // if keyword
-  WHILE,       // while keyword
-  FALSE,       // false keyword
-  TRUE,        // true keyword
-  NEW,         // new keyword
-  PLUS,        // + operator
-  MINUS,       // - operator
-  MUL,         // * operator
-  DIV,         // / operator
-  MOD,         // % operator
-  ASSIGN,      // = operator
-  EQ,          // == operator
-  NEQ,         // != operator
-  GT,          // > operator
-  GEQ,         // >= operator
-  LT,          // < operator
-  LEQ,         // <= operator
-  COLON,       // : token
-  COMMA,       // , token
-  ID,          // function (e.g. quicksort) or variable (e.g. len) identifiers
-  LBRACKET,    // [ token
-  RBRACKET,    // ] token
-  LPAR,        // ( token
-  RPAR,        // ) token
-  LBRACE,      // { token
-  RBRACE,      // } token
-  SEMICOLON    // ; token
+  UNDEFINED, // token of undefined kind (i.e. error)
+  EOI,       // end of input
+  INT_LIT,   // integer literal
+  INT,       // int keyword
+  BOOL,      // bool keyword
+  FUNC,      // func keyword
+  RETURN,    // return keyword
+  IF,        // if keyword
+  WHILE,     // while keyword
+  FALSE,     // false keyword
+  TRUE,      // true keyword
+  NEW,       // new keyword
+  PLUS,      // + operator
+  MINUS,     // - operator
+  MUL,       // * operator
+  DIV,       // / operator
+  MOD,       // % operator
+  ASSIGN,    // = operator
+  EQ,        // == operator
+  NEQ,       // != operator
+  GT,        // > operator
+  GEQ,       // >= operator
+  LT,        // < operator
+  LEQ,       // <= operator
+  COLON,     // : token
+  COMMA,     // , token
+  ID,        // function (e.g. quicksort) or variable (e.g. len) identifiers
+  LBRACKET,  // [ token
+  RBRACKET,  // ] token
+  LPAR,      // ( token
+  RPAR,      // ) token
+  LBRACE,    // { token
+  RBRACE,    // } token
+  SEMICOLON  // ; token
 };
 
 #endif

--- a/tokens_enum.hpp
+++ b/tokens_enum.hpp
@@ -18,10 +18,12 @@ enum class TOK {
   EOI,       // end of input
   INT_LIT,   // integer literal
   INT,       // int keyword
+  STRUCT,    // struct keyword
   BOOL,      // bool keyword
   FUNC,      // func keyword
   RETURN,    // return keyword
   IF,        // if keyword
+  ELSE,      // else keyword
   WHILE,     // while keyword
   FALSE,     // false keyword
   TRUE,      // true keyword
@@ -38,6 +40,9 @@ enum class TOK {
   GEQ,       // >= operator
   LT,        // < operator
   LEQ,       // <= operator
+  NOT,       // ! operator
+  AND_AND,   // && operator
+  OR_OR,     // || operator
   COLON,     // : token
   COMMA,     // , token
   ID,        // function (e.g. quicksort) or variable (e.g. len) identifiers
@@ -47,6 +52,7 @@ enum class TOK {
   RPAR,      // ) token
   LBRACE,    // { token
   RBRACE,    // } token
+  DOT,       // . token
   SEMICOLON  // ; token
 };
 

--- a/tokens_enum.hpp
+++ b/tokens_enum.hpp
@@ -14,45 +14,41 @@ Therefore to use an enumerator name we have to use the scope resolution
 operator. e.g. TOK::UNDEFINED
 */
 enum class TOK {
-  UNDEFINED,    // token of undefined kind (i.e. error)
-  EOI,          // end of input
-  INT_LIT,      // integer literal
-  STRING_LIT,   // string literal
-  MAIN,         // main keyword
-  INT,          // int keyword
-  BOOL,         // bool keyword
-  FUNCTION,     // func keyword
-  RETURN,       // return keyword
-  IF,           // if keyword
-  WHILE,        // while keyword
-  FALSE,        // false keyword
-  TRUE,         // true keyword
-  NEW,          // new keyword
-  PLUS,         // + operator
-  MINUS,        // - operator
-  MULT,         // * operator
-  DIV,          // / operator
-  MOD,          // % operator
-  ASSIGN,       // = operator
-  EQUAL,        // == operator
-  UNEQUAL,      // != operator
-  GREATER,      // > operator
-  GREQ,         // >= operator
-  LESS,         // < operator
-  LEQ,          // <= operator
-  TYPE_SPEC,    // : token
-  COMMA,        // , token
-  ID,           // function (e.g. quicksort) or variable (e.g. len) identifiers
-  LINE_COMM,    // // token
-  START_COMM,   // /* token
-  END_COMM,     // */ token
-  START_ARRAY,  // [ token
-  END_ARRAY,    // ] token
-  START_PAREN,  // ( token
-  END_PAREN,    // ) token
-  START_SCOPE,  // { token
-  END_SCOPE,    // } token
-  END_STATEMENT // ; token
+  UNDEFINED,   // token of undefined kind (i.e. error)
+  EOI,         // end of input
+  INT_LIT,     // integer literal
+  MAIN,        // main keyword
+  INT,         // int keyword
+  BOOL,        // bool keyword
+  FUNCTION,    // func keyword
+  RETURN,      // return keyword
+  IF,          // if keyword
+  WHILE,       // while keyword
+  FALSE,       // false keyword
+  TRUE,        // true keyword
+  NEW,         // new keyword
+  PLUS,        // + operator
+  MINUS,       // - operator
+  MULT,        // * operator
+  DIV,         // / operator
+  MOD,         // % operator
+  ASSIGN,      // = operator
+  EQUAL,       // == operator
+  UNEQUAL,     // != operator
+  GREATER,     // > operator
+  GREQ,        // >= operator
+  LESS,        // < operator
+  LEQ,         // <= operator
+  COLON,       // : token
+  COMMA,       // , token
+  ID,          // function (e.g. quicksort) or variable (e.g. len) identifiers
+  START_ARRAY, // [ token
+  END_ARRAY,   // ] token
+  START_PAREN, // ( token
+  END_PAREN,   // ) token
+  START_SCOPE, // { token
+  END_SCOPE,   // } token
+  SEMICOLON    // ; token
 };
 
 #endif

--- a/tokens_enum.hpp
+++ b/tokens_enum.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright: Copyright nsoul97 (Soulounias Nikolaos) 2019.
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   nsoul97 (Soulounias Nikolaos)
+ */
+
+#ifndef __TOK_ENUMS_HPP
+#define __TOK_ENUMS_HPP
+
+/*
+Enum class TOK is used to help identify the tokens of DIL language.
+Since this is an enum class, enumerator names are local to the TOK enum.
+Therefore to use an enumerator name we have to use the scope resolution
+operator. e.g. TOK::UNDEFINED
+*/
+enum class TOK {
+  UNDEFINED,    // token of undefined kind (i.e. error)
+  EOI,          // end of input
+  INT_LIT,      // integer literal
+  STRING_LIT,   // string literal
+  MAIN,         // main keyword
+  INT,          // int keyword
+  BOOL,         // bool keyword
+  FUNCTION,     // func keyword
+  RETURN,       // return keyword
+  IF,           // if keyword
+  WHILE,        // while keyword
+  FALSE,        // false keyword
+  TRUE,         // true keyword
+  NEW,          // new keyword
+  PLUS,         // + operator
+  MINUS,        // - operator
+  MULT,         // * operator
+  DIV,          // / operator
+  MOD,          // % operator
+  ASSIGN,       // = operator
+  EQUAL,        // == operator
+  UNEQUAL,      // != operator
+  GREATER,      // > operator
+  GREQ,         // >= operator
+  LESS,         // < operator
+  LEQ,          // <= operator
+  TYPE_SPEC,    // : token
+  COMMA,        // , token
+  ID,           // function (e.g. quicksort) or variable (e.g. len) identifiers
+  LINE_COMM,    // // token
+  START_COMM,   // /* token
+  END_COMM,     // */ token
+  START_ARRAY,  // [ token
+  END_ARRAY,    // ] token
+  START_PAREN,  // ( token
+  END_PAREN,    // ) token
+  START_SCOPE,  // { token
+  END_SCOPE,    // } token
+  END_STATEMENT // ; token
+};
+
+#endif


### PR DESCRIPTION
Issue: #3 
First go with the tokens enum class.
The enumerations in the enum are supposed to support the .dil sample source files.
(e.g. string keyword not included yet, since it is not used in is_prime.dil and quicksort.dil files)